### PR TITLE
give dependabot access to repo secrets to auto merge dependency updates

### DIFF
--- a/.github/workflows/frontend-deploy.yaml
+++ b/.github/workflows/frontend-deploy.yaml
@@ -13,6 +13,9 @@ on:
     paths:
       - "invoice-frontend/**" # Triggers on PRs that modify the frontend directory
       - ".github/workflows/frontend-deploy.yaml" # Triggers on PRs that modify the workflow file
+  pull_request_target:
+    branches:
+      - main
 
 jobs:
   test:
@@ -51,7 +54,9 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
-
+    if: |
+          (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
+          (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     steps:
       - name: Check NODE_ENV
         run: |
@@ -61,7 +66,14 @@ jobs:
         uses: catchpoint/workflow-telemetry-action@v2
 
       - name: Checkout Code
+        if: ${{ github.event_name != 'pull_request_target' }} 
         uses: actions/checkout@v4.2.2
+      
+      - name: Checkout Code for PR
+        if: ${{ github.event_name == 'pull_request_target' }} 
+        uses: actions/checkout@v4.2.2
+        with: 
+          ref: ${{ github.event.pull_request.head.sha }} 
 
       - name: Set up Node.js and Yarn
         uses: actions/setup-node@v4.1.0


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for frontend deployment to handle pull request targets and ensure appropriate conditions for job execution. The most important changes include adding a new event trigger for `pull_request_target`, setting job conditions based on the event type and actor, and modifying the checkout steps accordingly.

Changes to event triggers and job conditions:

* [`.github/workflows/frontend-deploy.yaml`](diffhunk://#diff-93fdaca9c193b84d2c910192c0426972e62204c0552c35329ca2594ece8240efR16-R18): Added a `pull_request_target` event trigger for the `main` branch to ensure workflows are triggered for pull request targets.
* [`.github/workflows/frontend-deploy.yaml`](diffhunk://#diff-93fdaca9c193b84d2c910192c0426972e62204c0552c35329ca2594ece8240efL54-R59): Added a conditional statement to execute jobs only if the event is a `pull_request_target` and the actor is `dependabot[bot]`, or if the event is not a `pull_request_target` and the actor is not `dependabot[bot]`.

Modifications to checkout steps:

* [`.github/workflows/frontend-deploy.yaml`](diffhunk://#diff-93fdaca9c193b84d2c910192c0426972e62204c0552c35329ca2594ece8240efR69-R77): Added a condition to skip the default code checkout step if the event is a `pull_request_target`.
* [`.github/workflows/frontend-deploy.yaml`](diffhunk://#diff-93fdaca9c193b84d2c910192c0426972e62204c0552c35329ca2594ece8240efR69-R77): Added a new checkout step specifically for pull request targets, using the pull request head SHA for the reference.